### PR TITLE
Keep pretraga on refresh

### DIFF
--- a/ied-fe/src/components/MyTable/MyTable.tsx
+++ b/ied-fe/src/components/MyTable/MyTable.tsx
@@ -21,13 +21,13 @@ export default memo(function MyTable(queryParameters: FirmaQueryParams) {
 
   useEffect(() => {
     const loadData = async () => {
-      const { pageIndex, pageSize } = table.getState().pagination;
+      const { pageIndex, pageSize } = pagination;
       const res = await fetchFirmaPretrage(pageSize, pageIndex, queryParameters);
       setData(res.firmas);
       setDocuments(res.totalDocuments);
     };
     loadData();
-  }, [pagination, documents, queryParameters]);
+  }, [pagination.pageIndex, pagination.pageSize, queryParameters]);
 
   const table = useMaterialReactTable({
     columns: useMemo<MRT_ColumnDef<FirmaType>[]>(() => myCompanyColumns, []),

--- a/ied-fe/src/components/MyTable/MyTable.tsx
+++ b/ied-fe/src/components/MyTable/MyTable.tsx
@@ -5,19 +5,16 @@ import {
   MaterialReactTable,
   type MRT_ColumnDef,
   useMaterialReactTable,
-  type MRT_PaginationState,
 } from "material-react-table";
 import { fetchFirmaPretrage } from "../../api/firma.api";
 import { FirmaQueryParams } from "@ied-shared/types/firmaQueryParams";
+import { usePretragaStore } from "../../store/pretragaParameters.store";
 
 export default memo(function MyTable(queryParameters: FirmaQueryParams) {
   const [data, setData] = useState<FirmaType[]>([]);
   const [documents, setDocuments] = useState(1000);
 
-  const [pagination, setPagination] = useState<MRT_PaginationState>({
-    pageIndex: 0,
-    pageSize: 50,
-  });
+  const { pagination, setPaginationParameters } = usePretragaStore();
 
   useEffect(() => {
     const loadData = async () => {
@@ -38,7 +35,14 @@ export default memo(function MyTable(queryParameters: FirmaQueryParams) {
     paginationDisplayMode: "default",
     positionToolbarAlertBanner: "bottom",
     manualPagination: true,
-    onPaginationChange: setPagination,
+    onPaginationChange: (updater) => {
+      if (typeof updater === "function") {
+        const newPagination = updater(pagination);
+        setPaginationParameters(newPagination);
+      } else {
+        setPaginationParameters(updater);
+      }
+    },
     enablePagination: true,
     state: {
       pagination,

--- a/ied-fe/src/components/PredefinedPretrage/PredefinedPretrage.tsx
+++ b/ied-fe/src/components/PredefinedPretrage/PredefinedPretrage.tsx
@@ -7,6 +7,7 @@ import type { TODO_ANY } from "../../../../ied-be/src/utils/utils";
 import { usePretragaStore } from "../../store/pretragaParameters.store";
 import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import ZoomOutIcon from "@mui/icons-material/ZoomOut";
+import { RestartAltOutlined } from "@mui/icons-material";
 
 export default function PredefinedPretrage() {
   const [pretrage, setPretrage] = useState<TODO_ANY[]>([]);
@@ -34,7 +35,7 @@ export default function PredefinedPretrage() {
     setOpenPretrageSaveDialog(true);
   };
 
-  const { pretragaParameters, setPretragaParameters } = usePretragaStore();
+  const { pretragaParameters, setPretragaParameters, resetParameters } = usePretragaStore();
 
   const handleSavePretraga = async (nazivPretrage: string, isNew: boolean) => {
     try {
@@ -119,6 +120,15 @@ export default function PredefinedPretrage() {
           onClick={handleDeletePretraga}
         >
           Obrisi pretragu
+        </Button>
+        <Button
+          startIcon={<RestartAltOutlined />}
+          variant="contained"
+          size="large"
+          color="info"
+          onClick={resetParameters}
+        >
+          Reset
         </Button>
       </Grid>
     </Grid>

--- a/ied-fe/src/pages/Pretrage.tsx
+++ b/ied-fe/src/pages/Pretrage.tsx
@@ -17,14 +17,20 @@ if (!PUBLISHABLE_KEY) {
 }
 
 export default function Pretrage() {
-  const { pretragaParameters, appliedParameters, applyParameters, loadFromStorage } =
-    usePretragaStore();
+  const {
+    pretragaParameters,
+    appliedParameters,
+    applyParameters,
+    loadFromStorage,
+    setPaginationParameters,
+  } = usePretragaStore();
 
   useEffect(() => {
     loadFromStorage();
   }, [loadFromStorage]);
 
   const handlePretraziClick = () => {
+    setPaginationParameters({ pageIndex: 0, pageSize: 50 });
     applyParameters();
   };
 

--- a/ied-fe/src/pages/Pretrage.tsx
+++ b/ied-fe/src/pages/Pretrage.tsx
@@ -4,7 +4,7 @@ import Divider from "@mui/material/Divider";
 import PredefinedPretrage from "../components/PredefinedPretrage/PredefinedPretrage";
 import PretragaParameters from "../components/PretragaParameters/PretragaParameters";
 import ExportDataButton from "../components/SaveDataButton";
-import { useState } from "react";
+import { useEffect } from "react";
 import { usePretragaStore } from "../store/pretragaParameters.store";
 import { Box, Button } from "@mui/material";
 import AddBoxIcon from "@mui/icons-material/AddBox";
@@ -17,12 +17,15 @@ if (!PUBLISHABLE_KEY) {
 }
 
 export default function Pretrage() {
-  const { pretragaParameters } = usePretragaStore();
+  const { pretragaParameters, appliedParameters, applyParameters, loadFromStorage } =
+    usePretragaStore();
 
-  const [appliedParameters, setAppliedParameters] = useState(pretragaParameters);
+  useEffect(() => {
+    loadFromStorage();
+  }, [loadFromStorage]);
 
   const handlePretraziClick = () => {
-    setAppliedParameters(pretragaParameters);
+    applyParameters();
   };
 
   return (

--- a/ied-fe/src/store/pretragaParameters.store.ts
+++ b/ied-fe/src/store/pretragaParameters.store.ts
@@ -3,59 +3,52 @@ import { create } from "zustand";
 
 type PretragaStore = {
   pretragaParameters: FirmaQueryParams;
+  appliedParameters: FirmaQueryParams;
   setPretragaParameters: (params: Partial<FirmaQueryParams>) => void;
   toggleNegation: (value: string) => void;
+  applyParameters: () => void;
+  loadFromStorage: () => void;
+  resetParameters: () => void;
 };
 
-export const usePretragaStore = create<PretragaStore>((set) => ({
-  pretragaParameters: {
-    imeFirme: "",
-    pib: "",
-    email: "",
-    velicineFirmi: [],
-    radnaMesta: [],
-    tipoviFirme: [],
-    delatnosti: [],
-    mesta: [],
-    negacije: [],
-    stanjaFirme: [],
-    jbkjs: "",
-    maticniBroj: "",
-    komentar: "",
-    seminari: [],
-    imePrezime: "",
-    emailZaposlenog: "",
-  },
+const STORAGE_KEY = 'appliedPretragaParameters'
+
+const defaultParameters: FirmaQueryParams = {
+  imeFirme: "",
+  pib: "",
+  email: "",
+  velicineFirmi: [],
+  radnaMesta: [],
+  tipoviFirme: [],
+  delatnosti: [],
+  mesta: [],
+  negacije: [],
+  stanjaFirme: [],
+  jbkjs: "",
+  maticniBroj: "",
+  komentar: "",
+  seminari: [],
+  imePrezime: "",
+  emailZaposlenog: "",
+};
+
+export const usePretragaStore = create<PretragaStore>((set, get) => ({
+  pretragaParameters: defaultParameters,
+  appliedParameters: defaultParameters,
   setPretragaParameters: (params) =>
-    set((state) => {
-      const updatedParameters = {
+    set((state) => ({
+      pretragaParameters: {
         ...state.pretragaParameters,
         ...params,
-      };
-
-      // Only update the state if there is an actual change
-      if (JSON.stringify(state.pretragaParameters) !== JSON.stringify(updatedParameters)) {
-        return {
-          pretragaParameters: updatedParameters,
-        };
-      }
-
-      return state;
-    }),
-  // }),
+      },
+    })),
   toggleNegation: (value) =>
     set((state) => {
-      if (!state.pretragaParameters.negacije) {
-        return {
-          pretragaParameters: {
-            ...state.pretragaParameters,
-            negacije: [],
-          },
-        };
-      }
-      const negacije = state.pretragaParameters.negacije.includes(value)
-        ? state.pretragaParameters.negacije.filter((v) => v !== value)
-        : [...state.pretragaParameters.negacije, value];
+
+      const currentNegacije = state.pretragaParameters.negacije || [];
+      const negacije = currentNegacije.includes(value)
+        ? currentNegacije.filter((v) => v !== value)
+        : [...currentNegacije, value];
 
       return {
         pretragaParameters: {
@@ -64,4 +57,26 @@ export const usePretragaStore = create<PretragaStore>((set) => ({
         },
       };
     }),
+  applyParameters: () => {
+    const { pretragaParameters } = get();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(pretragaParameters));
+    set({ appliedParameters: pretragaParameters });
+  },
+  loadFromStorage: () => {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      const appliedParameters = JSON.parse(saved);
+      set({
+        appliedParameters,
+        pretragaParameters: appliedParameters
+      });
+    }
+  },
+  resetParameters: () => {
+    set({
+      pretragaParameters: defaultParameters,
+      appliedParameters: defaultParameters
+    });
+    localStorage.removeItem(STORAGE_KEY);
+  },
 }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Reset" button to the predefined searches section, allowing users to quickly clear all search parameters and pagination settings.
	- Search parameters and pagination are now automatically saved and restored between sessions.
- **Improvements**
	- Pagination and search state management are now centralized, providing a more consistent experience across the app.
	- Search actions now explicitly reset pagination to the first page with a standard page size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->